### PR TITLE
Update control

### DIFF
--- a/control
+++ b/control
@@ -7,3 +7,4 @@ Maintainer: ConorTheDev <con0r.b@protonmail.com>
 Author: ConorTheDev, Nepeta
 Section: Development
 Depends: mobilesubstrate, me.conorthedev.thiccaudiosnapshotserver, me.conorthedev.libconorthedev, firmware (>= 11.0)
+Provides: me.nepeta.libmitsuha


### PR DESCRIPTION
This allows Mitsuhaforever to be installed along side tweaks such as StatusViz as currently they both depend on different libmitsuhas  so both can not be installed.